### PR TITLE
fix tweet scraping when there are many retweets in a row

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -67,7 +67,7 @@ def download_tweet_media(tweet):
     """try to download images linked in tweet"""
     if 'extended_entities' in tweet and 'media' in tweet['extended_entities']:
         for media in tweet['extended_entities']['media']:
-            print('{}:'.format(tweet['user']['screen_name']))
+            print('{}/{}:'.format(tweet['user']['screen_name'], tweet['id_str']))
             if 'video_info' in media:
                 return
             else:
@@ -132,7 +132,7 @@ if __name__ == "__main__":
             'compression': False,
             'tweet_mode': 'extended',
             'exclude_replies': True,
-            'include_rts': False,
+            # 'include_rts': False,
             }
 
     conn = sqlite3.connect('working/twitter_scraper.db')
@@ -167,6 +167,7 @@ if __name__ == "__main__":
         while num_tweets > 0:
             for tweet in tweets:
                 tweet = tweet._json
+
                 # update last tweet read
                 if last_id is None or tweet['id'] > last_id:
                     try:
@@ -180,6 +181,10 @@ if __name__ == "__main__":
                 if first_id is None or tweet['id'] < first_id:
                     first_id = tweet['id']
 
+                # skip if tweet is actually a retweet
+                if 'retweeted_status' in tweet:
+                    continue
+
                 # download tweet media
                 download_tweet_media(tweet)
 
@@ -189,5 +194,3 @@ if __name__ == "__main__":
             else:
                 tweets = api.user_timeline(user, since_id=last_id+1, **tweepy_kwargs)
             num_tweets = len(tweets)
-
-

--- a/find_match.py
+++ b/find_match.py
@@ -104,7 +104,9 @@ def secs_to_str(secs):
     SECS_PER_HR = SECS_PER_MIN * 60
     SECS_PER_DAY = SECS_PER_HR * 24
 
-    if secs < SECS_PER_MIN: if secs == 1: return '1 second'
+    if secs < SECS_PER_MIN:
+        if secs == 1:
+            return '1 second'
         else:
             return '{} seconds'.format(secs)
     if secs < SECS_PER_HR:


### PR DESCRIPTION
Fixes #6 

If a Twitter user retweeted many times in a row without a normal tweet, the tweet scraper would fail to scrape any earlier tweets. We no longer use 'include_rts' = False, instead we scrape every tweet, and only process those that don't have the 'retweeted_status' field.